### PR TITLE
String 과제

### DIFF
--- a/string/단어 정렬.kt
+++ b/string/단어 정렬.kt
@@ -1,0 +1,22 @@
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+
+// https://www.acmicpc.net/problem/1181
+
+fun main(args: Array<String>) {
+    val br = BufferedReader(InputStreamReader(System.`in`))
+    val bw = BufferedWriter(OutputStreamWriter(System.out))
+    val words = mutableSetOf<String>()
+    repeat(br.readLine().toInt()) {
+        words.add(br.readLine())
+    }
+
+    words.sortedWith(compareBy({ it.length }, { it })).forEach {
+        bw.write("$it\n")
+    }
+
+    bw.close()
+    br.close()
+}

--- a/string/부분 문자열.kt
+++ b/string/부분 문자열.kt
@@ -1,0 +1,33 @@
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+// https://www.acmicpc.net/problem/16916
+
+fun main(args: Array<String>) {
+    val br = BufferedReader(InputStreamReader(System.`in`))
+    print(kmp(br.readLine(), br.readLine()))
+}
+
+fun makeTable(pattern: String): IntArray {
+    val table = IntArray(pattern.length); var j = 0
+    for (i in 1 until pattern.length) {
+        while (j > 0 && pattern[i] != pattern[j]) j = table[j - 1]
+        if (pattern[i] == pattern[j]) table[i] = ++j
+    }
+
+    return table
+}
+
+fun kmp(origin: String, pattern: String): Int {
+    val table = makeTable(pattern); var j = 0
+
+    for (i in origin.indices) {
+        while (j > 0 && origin[i] != pattern[j]) j = table[j - 1]
+        if (origin[i] == pattern[j]) {
+            if (j == pattern.length - 1) return 1
+            else j++
+        }
+    }
+
+    return 0
+}


### PR DESCRIPTION
# 단어 정렬
- `sortedWith`을 사용하여 멀티 조건에 따라 정렬을 적용했습니다.
- 입력된 단어 저장 시 `mutableSet`을 이용하여 중복 단어를 제거했습니다.

- 참고
    1. `sortedWith()` : mmutable list에서 사용
    2. `sortWith()` : Mutable list에서 사용

- 시간 복잡도 : O(sortedWith의 시간복잡도) // 코드 파고들어가봤는데 사진과 같이 내부 구현 내용은 확인 할 수 없었습니다...

<img width="894" alt="image" src="https://user-images.githubusercontent.com/48701368/183624965-450fccad-f8a4-48ae-a947-62fd2ae14bce.png">

<img width="645" alt="image" src="https://user-images.githubusercontent.com/48701368/183624875-67a4d725-78df-4b52-942a-3e6eb5d461c3.png">

<img width="153" alt="image" src="https://user-images.githubusercontent.com/48701368/183626325-6f2d0bf1-4986-418f-970a-7e3def0f5ea3.png">

<br>

# 부분 문자열 풀이
- 처음에 `Strings` 내장 함수인 `contain()`을 사용하여 풀이하면서 문제 잘못냈다고 생각했습니다.
- 하지만 그럴 필요 없이 시간초과가 떠버렸습니다^^ 역시 실버 1은 만만하지 않네요...
- 구글링을 해보니 `KMP`를 사용해야한다는 걸 깨달았죠!
- 저는 글보고 이해하는데 시간이 굉장히 오래걸릴 것 같아 [영상](https://www.youtube.com/watch?v=yWWbLrV4PZ8)으로 이해했습니다.
- _사실 코테에서 `KMP`를 직접 구현하라고 할 것 같진 않지만,, O(N)이라는 시간복잡도 내에 부분문자열을 구할 수 있다는 걸 알았단 것만으로도 큰 수확이라고 생각합니다!_
- 시간 복잡도 : O(N+M) -> O(N) // N(전체 문자열 길이), M(패턴 문자열 길이)

### KMP
- KMP 알고리즘의 메인 아이디어는 다음과 같습니다.

> _문자열이 불일치 할 때 탐색을 시작했던 위치의 다음 문자 부터가 아닌, 앞서 탐색했던 정보를 이용하여 몇칸 정도는 건너 뛴 후 탐색해보자!_
- 핵심은 접두사와 접미사가 일치하는 경우에 문자열 매칭을 탐색할 때 점프(문자열이 일치하지 않았을 경우의 어디로 Jump 할지에 대한 Table이 필요)를 할 수 있어서 굉장히 효율적으로 작동하게 된다는 것입니다.

#### 부분 일치 Table 정의
- 접두사도 되고 접미사도 되는 문자열의 최대 길이를 저장해주는 table 정의합니다.
- 접두사의 위치를 j, 접미사의 위치를 i라고 한다면, 기본적인 동작과정은 j와 i가 일치하는 경우, j와 i가 일치하지 않는 경우에 따라 나뉩니다.

1. `j와 i위치의 문자가 일치한 경우` : 해당 위치에서 접두사와 접미사가 일치하다는 의미로 그 다음 위치를 탐색해야하므로 j와 i의 위치를 오른쪽으로 한 칸씩 이동

2. `j와 i위치의 문자가 일치하지 않는 경우` : 접두사와 접미사가 불일치하다는 의미로 접두사와 접미사의 일치 여부가 담긴 table을 참고하여 j의 위치를 table[j-1]에서 가리키는 위치로 이동시킨다. (j-1)인 이유는 최소 j-1위치까지는 접두사와 접미사가 일치하다는 의미로 j의 이동을 최소화할 수 있다.

<img width="153" alt="image" src="https://user-images.githubusercontent.com/48701368/183626245-82ac9b9c-634b-405e-9d04-08bdfddc4693.png">
