### PR TITLE
Backtracking 과제

### DIFF
--- a/backtracking/n-queen.kt
+++ b/backtracking/n-queen.kt
@@ -1,0 +1,39 @@
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import kotlin.math.abs
+
+//https://www.acmicpc.net/problem/9663
+
+val br = BufferedReader(InputStreamReader(System.`in`))
+val size = br.readLine().toInt()
+val chess = IntArray(size)
+var count = 0
+
+fun main(args: Array<String>) {
+    backtrack(0)
+    print(count)
+}
+
+fun backtrack(currentRow: Int) {
+    // 1. 퀸이 배치된 행수가 총 N개가 되면, count값을 1씩 증가
+    if (currentRow == size) {
+        count++
+        return
+    }
+
+    // 2. 그렇지 않은 경우, 현재 행에서 모든 열을 검사
+    for (i in chess.indices) {
+        // 2.1. 행 위치에 열 값을 할당
+        chess[currentRow] = i
+        // 2.2.1. 현재 퀸의 위치가 유망한 경우, 다음 행 검사
+        if (isPromising(currentRow)) backtrack(currentRow + 1)
+        // 2.2.2. 유망하지 않은 경우, 반복문 진행
+    }
+}
+
+fun isPromising(currentRow: Int): Boolean {
+    // 같은 열에 있는 지 검사 : queen[currentRow(현재 행)] == chess[j(행)]
+    // 대각 선 상에 존재하는 지 검사 : 행거리 == 열거리 -> currentRow - ㅓ == abs(chess[currentRow] - chess[j])
+    for (j in 0 until currentRow) if (chess[currentRow] == chess[j] || currentRow - j == abs(chess[currentRow] - chess[j])) return false
+    return true
+}


### PR DESCRIPTION
# n-queen
- 풀이 방식 :
1차원 배열을 생성하여 index를 행 값으로 보고, index에 위치한 값을 열 값으로 지정하여 풀이했습니다!
한 행에  하나의 퀸을 배치한다는 조건에 의해 1차원 배열로 퀸의 위치를 나타낼 수 있었습니다.
예시로 4x4 체스판에서 다음과 같이 퀸의 위치를 나타낸 것입니다.
```
col[1] = 2 -> 1행 2열에 퀸이 존재
col[2] = 4 -> 2행 4열에 퀸이 존재
col[3] = 1 -> 3행 1열에 퀸이 존재
col[4] = 3 -> 4행 3열에 퀸이 존재
```
 
- 퀸의 배치에 대한 유망성을 검사하는 함수로, 더 자세한 설명은 코드에서 주석을 확인해주세요!

```kotlin
fun isPromising(currentRow: Int): Boolean {
    // 같은 열에 있는 지 검사 : queen[currentRow(현재 행)] == chess[j(행)]
    // 대각 선 상에 존재하는 지 검사 : 행거리 == 열거리 -> currentRow - ㅓ == abs(chess[currentRow] - chess[j])
    for (j in 0 until currentRow) if (chess[currentRow] == chess[j] || currentRow - j == abs(chess[currentRow] - chess[j])) return false
    return true
}
```

- 시간복잡도 : O(n^n)
<img width="153" alt="image" src="https://user-images.githubusercontent.com/48701368/184477906-19a8c77a-4ee1-4458-9ba0-82573c9c5645.png">
