### PR TITLE
Implementation 과제

### DIFF
--- a/implementation/괄호.kt
+++ b/implementation/괄호.kt
@@ -19,7 +19,7 @@ fun checkVps(ps: String): Boolean {
         if (c == '(') {
             stack.add(c)
         } else {
-            if (stack.isNotEmpty() && stack.last() == '(') stack.removeLast()
+            if (stack.isNotEmpty()) stack.removeLast()
             else return false
         }
     }

--- a/implementation/괄호.kt
+++ b/implementation/괄호.kt
@@ -1,0 +1,28 @@
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+// https://www.acmicpc.net/problem/9012
+
+fun main() {
+    val br = BufferedReader(InputStreamReader(System.`in`))
+    val result = mutableListOf<Boolean>()
+
+    repeat(br.readLine().toInt()) {
+        result.add(checkVps(br.readLine()))
+    }
+    result.forEach { println(if (it) "YES" else "NO") }
+}
+
+fun checkVps(ps: String): Boolean {
+    val stack = mutableListOf<Char>()
+    for (c in ps) {
+        if (c == '(') {
+            stack.add(c)
+        } else {
+            if (stack.isNotEmpty() && stack.last() == '(') stack.removeLast()
+            else return false
+        }
+    }
+
+    return stack.size == 0
+}

--- a/implementation/듣보잡.kt
+++ b/implementation/듣보잡.kt
@@ -1,0 +1,19 @@
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+// https://zion830.tistory.com/127
+
+fun main() {
+    val br = BufferedReader(InputStreamReader(System.`in`))
+    val noHear = mutableSetOf<String>()
+    val noSee = mutableSetOf<String>()
+    val (n, m) = br.readLine().split(" ").map { it.toInt() }
+
+    repeat(n) { noHear.add(br.readLine()) }
+    repeat(m) { noSee.add(br.readLine()) }
+
+    val result = noHear.intersect(noSee)
+
+    println(result.size)
+    result.sorted().forEach { println(it) }
+}


### PR DESCRIPTION
# 괄호
- 풀이 방식 : mutableListOf을 스택처럼 이용해서 풀이했습니다! 아래 코드에서 주석 참고 부탁드립니다~
```kotlin
for (c in ps) {
        if (c == '(') { // 열린 괄호인 경우 스택에 push
            stack.add(c)
        } else { // 닫힌 괄호인 경우
            if (stack.isNotEmpty() && stack.last() == '(') stack.removeLast() // 스택이 비어있지 않으면서 top 원소가 열린 괄호인 경우 스택에서 괄호 제거
            else return false // vps 탈락
        }
    }
```
- 시간 복잡도 : O(n*l) // n = 입력한 문자열 갯수, l = 해당 문자열의 길이
<img width="153" alt="image" src="https://user-images.githubusercontent.com/48701368/185381310-3f6f7dde-e748-4002-a694-681c97b3fc8b.png">

# 듣보잡
- 코틀린 set의 intersect()를 알게된 문제였습니다!
- intersect 내부 구현을 살펴보니 retainAll를 사용하고 있네요
- 풀이 방식 : noHear(듣도 못한 사람)과 noSee(보도 못한 사람)을 set에 추가한 후 두 set의 교집합을 구했습니다!
- 시간 복잡도 : O(nlogn) // 사전순 정렬 적용 ~~O(alogb) // a = hashSet A의 size, b = hashSet B의 size~~
- 참고 : [retainAll() 시간복잡도 분석](https://codingdog.tistory.com/entry/java-retainAll-%EB%A9%94%EC%86%8C%EB%93%9C%EB%A5%BC-%EA%B0%84%EB%8B%A8%ED%95%98%EA%B2%8C-%EB%B6%84%EC%84%9D%ED%95%B4-%EB%B4%85%EC%8B%9C%EB%8B%A4)

<img width="182" alt="image" src="https://user-images.githubusercontent.com/48701368/185383939-6cdd35aa-4514-4350-910f-fe951e34e4d2.png">
