### PR TITLE
Implementation 과제

### DIFF
--- a/implementation/봄버맨.kt
+++ b/implementation/봄버맨.kt
@@ -1,12 +1,11 @@
 // https://www.acmicpc.net/problem/16918
 
-var bombs: MutableList<MutableList<Bomb>> = mutableListOf()
-
 data class Bomb(
     var status: Char,
     var time: Int
 )
 
+var bombs: MutableList<MutableList<Bomb>> = mutableListOf()
 fun main() {
     val br = System.`in`.bufferedReader()
     val (r, c, n) = br.readLine().split(" ").map { it.toInt() }
@@ -16,6 +15,7 @@ fun main() {
     }
 
     var sec = 1
+    val flag: MutableList<MutableList<Boolean>> = mutableListOf()
     while (sec < n) {
         sec++
         when (sec % 2) {
@@ -40,8 +40,7 @@ fun installBombs(r: Int, c: Int, s: Int) {
 }
 
 /** 3초 전에 설치된 폭탄이 제거됨 */
-fun uninstallBombs(r: Int, c: Int, s: Int) {
-    val flag: MutableList<MutableList<Boolean>> = mutableListOf()
+fun uninstallBombs(r: Int, c: Int, s: Int, flag: MutableList) {
     for (row in 0 until r) {
         flag.add(mutableListOf())
         for (col in 0 until c) {

--- a/implementation/봄버맨.kt
+++ b/implementation/봄버맨.kt
@@ -1,0 +1,69 @@
+// https://www.acmicpc.net/problem/16918
+
+var bombs: MutableList<MutableList<Bomb>> = mutableListOf()
+
+data class Bomb(
+    var status: Char,
+    var time: Int
+)
+
+fun main() {
+    val br = System.`in`.bufferedReader()
+    val (r, c, n) = br.readLine().split(" ").map { it.toInt() }
+    for (row in 0 until r) {
+        bombs.add(mutableListOf())
+        for (ch in br.readLine()) bombs[row].add(Bomb(ch, 0))
+    }
+
+    var sec = 1
+    while (sec < n) {
+        sec++
+        when (sec % 2) {
+            0 -> installBombs(r, c, sec)
+            1 -> uninstallBombs(r, c, sec)
+        }
+    }
+    printBombs()
+}
+
+/** 폭탄이 설치되어 있지 않은 모든 칸에 폭탄을 설치함 */
+fun installBombs(r: Int, c: Int, s: Int) {
+    for (row in 0 until r) {
+        for (col in 0 until c) {
+            if (bombs[row][col].status == ('O')) continue
+            bombs[row][col].apply {
+                status = 'O'
+                time = s
+            }
+        }
+    }
+}
+
+/** 3초 전에 설치된 폭탄이 제거됨 */
+fun uninstallBombs(r: Int, c: Int, s: Int) {
+    val flag: MutableList<MutableList<Boolean>> = mutableListOf()
+    for (row in 0 until r) {
+        flag.add(mutableListOf())
+        for (col in 0 until c) {
+            flag[row].add(bombs[row][col].status == 'O' && s - bombs[row][col].time == 3)
+        }
+    }
+
+    for (row in 0 until r) {
+        for (col in 0 until c) {
+            if (!flag[row][col]) continue
+            bombs[row][col].status = '.'
+            if (row > 0) bombs[row - 1][col].status = '.'
+            if (row < r - 1) bombs[row + 1][col].status = '.'
+            if (col > 0) bombs[row][col - 1].status = '.'
+            if (col < c - 1) bombs[row][col + 1].status = '.'
+        }
+    }
+}
+
+fun printBombs() {
+    for (row in bombs) {
+        for (bomb in row) print(bomb.status)
+        println()
+    }
+}


### PR DESCRIPTION
# 봄버맨
- 폭탄은 숫자'0'이 아니라 알파벳'O'이네요 ^^ 상당히 킹받는 부분 ㅎㅎ
- 풀이 방식 : 
```
0초: 초기값
1초: 유지
2초: 폭탄 설치
3초: 0초(3-0 = 3)에 놓은 폭탄 + 상하좌우 폭탄 제거
4초: 폭탄 설치
5초: 2초(5-2 = 3)에 놓은 폭탄 + 상하좌우 폭탄 제거
6초: 폭탄 설치
```
- 짝수 초일 때는 폭탄이 설치되지 않는 곳에 폭탄이 설치되고 -> `installBombs()` 호출
- 홀수 초일 때는 현재 초 - 설치된 초가 3초인 폭탄과 해당 폭탄의 상하좌우에 위치한 폭탄이 제거됩니다. -> `uninstallBombs()` 호출
- 시행착오 : 처음에는 아래 사진과 같이 코드를 작성했지만, 해당 코드를 돌릴 경우 테스트 케이스를 통과하지 못했습니다. 그 이유는 if문 조건인 "현재 초 - 설치된 초가 3초"에 해당하는 폭탄a가 바로 제거되면서 상하좌우에 위치한 폭탄 b,c,d,e까지 제거되버리는 문제가 있습니다. 이것이 왜 문제냐면 상하좌우에 있던 폭탄 b,c,d,e가 포문을 돌면서 if문에 들어올 수 있는 경우도 있을텐데 앞서 폭탄a가 제거되면서 함께 제거되어 if문에 들어오지 못하고, b,c,d,e의 상하좌우 폭탄이 제거되지 못합니다..! 
- 해결 : 따라서 반목문을 돌고 있는 동안에는 if문에 해당하는 폭탄과 상하좌우 폭탄을 제거하지 않고, 제거될 폭탄을 표시(flag)만 해두고 있습니다! 반복문을 모두 돌았을 경우, 한꺼번에 표시한 폭탄을 모두 제거합니다 :)
<img width="801" alt="image" src="https://user-images.githubusercontent.com/48701368/188315553-e9bb7330-c42a-4f9e-9058-73e66c94e2c8.png">

- 시간 복잡도 : O(n*n)
<img width="208" alt="image" src="https://user-images.githubusercontent.com/48701368/188315179-2100d533-f528-497c-83a3-3f9e83558c40.png">

