### PR TITLE
BruteForce 과제

### DIFF
--- a/bruteforce/체스판 다시 칠하기.kt
+++ b/bruteforce/체스판 다시 칠하기.kt
@@ -1,0 +1,41 @@
+import kotlin.math.max
+import kotlin.math.min
+
+// https://www.acmicpc.net/problem/1018
+
+fun main() {
+    val br = System.`in`.bufferedReader()
+    val chess = ArrayList<CharArray>()
+    val (row, col) = br.readLine().split(" ").map { it.toInt() }
+
+    repeat(row) {
+        chess.add(br.readLine().toCharArray())
+    }
+
+    var min = 64
+    var countBlack: Int
+    var countWhite: Int
+
+    // 1. 8X8 체스판탐색
+    for (r in 0 until row - 7) {
+        for (c in 0 until col - 7) {
+            countWhite = 0; countBlack = 0
+
+            // 2. 다시 칠해야할 정사각형 수의 최소값 구하기
+            for (i in r until r + 8) {
+                for (j in c until c + 8) {
+                    if ((i + j) % 2 == 0) {
+                        if (chess[i][j] == 'W') countBlack++
+                        else countWhite++
+                    } else {
+                        if (chess[i][j] == 'W') countWhite++
+                        else countBlack++
+                    }
+                }
+            }
+            min = min(min, min(countWhite, countBlack))
+        }
+    }
+
+    println(min)
+}


### PR DESCRIPTION
# 체스판 다시 칠하기
- 풀이 방식 : 
브루트포스로 nxn크기의 체스판에서 8x8크기의 체스판을 모두 탐색하면서 해당 8x8 체스판에서 칠할 개수를 구함

체스판의 시작점(0, 0 -> 열 + 행 % 2 == 0)이 검은색일 때와 흰색으로 시작하는 두 가지 경우를 모두 고려한다.
다시 칠해야하는 정사각형의 최솟값은 시작점을 기준으로 *blackCount, *whiteCouont를 구한 후 이 둘의 최소값 구하고, 각 체스판의 최솟값을 구하며 min 값을 갱신해갑니다.

*blackCount : 검정색으로 몇 번의 칠해야하는지 나타냄
*whiteCouont : 흰색으로 몇 번의 칠해야하는지 나타냄

- 시간 복잡도 : O(nxn)
<img width="151" alt="image" src="https://user-images.githubusercontent.com/48701368/188613623-63d976f3-7110-4e5b-a229-45438eec9e20.png">
