### PR TITLE
Search 과제

### DIFF
--- a/search/나무 자르기.kt
+++ b/search/나무 자르기.kt
@@ -1,0 +1,35 @@
+// https://www.acmicpc.net/problem/2805
+
+lateinit var trees: List<Long>
+fun main() {
+    val br = System.`in`.bufferedReader()
+    val (_, m) = br.readLine().split(" ").map { it.toInt() }
+    trees = br.readLine().split(" ").map { it.toLong() }
+
+    println(getMaxHeightOfCutter(m, trees.maxOrNull() ?: return))
+}
+
+fun getMaxHeightOfCutter(m: Int, maxTreeLength: Long): Long {
+    var total: Long
+    var mid: Long
+    var min = 1L
+    var max = maxTreeLength
+    var ans = 0L
+
+    while (min <= max) {
+        mid = (min + max) / 2
+        total = trees.sumOf { tree ->
+            (tree - mid).let { rest ->
+                if (rest > 0) rest else 0
+            }
+        }
+
+        if (total >= m) {
+            min = mid + 1
+            ans = mid
+        } else {
+            max = mid - 1
+        }
+    }
+    return ans
+}

--- a/search/랜선 자르기.kt
+++ b/search/랜선 자르기.kt
@@ -1,0 +1,34 @@
+// https://www.acmicpc.net/problem/1654
+
+val cables = mutableListOf<Long>()
+fun main() {
+    val br = System.`in`.bufferedReader()
+    val (k, n) = br.readLine().split(" ").map { it.toInt() }
+
+    repeat(k) {
+        cables.add(br.readLine().toLong())
+    }
+
+    println(getMaxLengthOfCable(n, cables.maxOrNull() ?: return))
+}
+
+fun getMaxLengthOfCable(n: Int, maxCableLength: Long): Long {
+    var count: Long
+    var mid: Long
+    var min = 1L
+    var max = maxCableLength
+    var ans = 0L
+
+    while (min <= max) {
+        mid = (min + max) / 2
+        count = cables.sumOf { it / mid }
+
+        if (count >= n) {
+            min = mid + 1
+            ans = mid
+        } else {
+            max = mid - 1
+        }
+    }
+    return ans
+}


### PR DESCRIPTION
# [랜선 자르기](https://www.acmicpc.net/problem/1654)
- 풀이 방식 : 이분탐색으로 풀이했습니다 :) 
- 최대 랜선 기준으로 길이를 1씩 줄여가면서 선형탐색으로 풀어봤는데 역시나 시간초과 뜨네요 ^^
- 사용되지 않는 변수는 "_"로 표기해보았습니다 ㅎㅎ Thanks to @murjune
- 시간 복잡도 : O(n)
- 이분 탐색 자체는 O(logn)의 시간복잡도를 갖지만 이분탐색을 적용하기 전 `maxOrNull()`로 최댓값을 찾습니다. `maxOrNull()`은 다음과 같이 선형탐색이 적용되기 때문에 O(n)의 시간복잡도를 갖습니다. 따라서 시간복잡도는 O(n)입니다 :)
<img width="147" alt="image" src="https://user-images.githubusercontent.com/48701368/191408630-b675ac14-2cb3-4774-af6d-86ded39d03d7.png">

# [나무 자르기](https://www.acmicpc.net/problem/2805)
- 풀이 방식 : 랜선자르기와 동일합니다~~ 랜선자르기와의 차이점은 mid값 갱신 기준입니다💡
- **랜선자르기**에서 mid 값 갱신의 기준은 아래와 같이 랜선의 개수 count 입니다.
```kotlin
count = cables.sumOf { it / mid }
```

- **나무 자르기**에서는 절단기로 자른 나무 윗 부분의 합이죠
```kotlin
total = trees.sumOf { tree ->
            (tree - mid).let { rest ->
                if (rest > 0) rest else 0
            }
        }
```
- 시간 복잡도 : O(n) // 랜선 자르기와 마찬가지 입니다!
<img width="147" alt="image" src="https://user-images.githubusercontent.com/48701368/191408605-5e1c4106-0458-4a73-a31b-6b6ca0996579.png">


- 이번에는 모두 이분 탐색 문제로 한 문제 풀면 나머지 문제는 앞서 푼 문제에서 일부 코드만 수정하여 쉽게 풀이할 수 있는 문제였습니다~~ 요즘 코테 슬럼프 왔었는데,, 이번 문제로 극복이 된 것 같기도 합니다 :) 모두들 화이팅입니다~~