### PR TITLE
Greedy 과제

### DIFF
--- a/greedy/섬 연결하기.kt
+++ b/greedy/섬 연결하기.kt
@@ -1,0 +1,86 @@
+// https://school.programmers.co.kr/learn/courses/30/lessons/42861?language=kotlin
+
+fun main() {
+    println(
+        solution1(
+            4,
+            arrayOf(
+                intArrayOf(0, 1, 1),
+                intArrayOf(0, 2, 2),
+                intArrayOf(1, 2, 5),
+                intArrayOf(1, 3, 1),
+                intArrayOf(2, 3, 8),
+            )
+        )
+    )
+}
+
+lateinit var parents: Array<Int>
+
+fun solution1(n: Int, costs: Array<IntArray>): Int {
+    costs.sortBy { it[2] }
+    parents = Array(n) { it }
+    var ans = 0
+
+    costs.forEach { cost ->
+        val p0 = findParent(cost[0])
+        val p1 = findParent(cost[1])
+
+        if (p0 != p1) {
+            if (p0 < p1) parents[p1] = p0
+            else parents[p0] = p1
+            ans += cost[2]
+        }
+    }
+
+    return ans
+}
+
+fun findParent(node: Int): Int {
+    if (parents[node] == node) return node
+    return findParent(parents[node])
+}
+
+fun solution2(n: Int, costs: Array<IntArray>): Int {
+    costs.sortBy { it[2] }
+    var i = 1
+    var ans = costs[0][2]
+    val routes = mutableListOf(mutableSetOf(costs[0][0], costs[0][1]))
+
+    while (i < costs.size && routes[0].size < n) {
+        var state = 0 // 두 노드 모두 방문한 적 없는 상태
+        routes.forEach { route ->
+            if (route.contains(costs[i][0]) && route.contains(costs[i][1])) {
+                state = 1 // 두 노드를 방문했으며 두 노드가 이미 이어진 상태
+                return@forEach
+            } else if ((route.contains(costs[i][0]) && !route.contains(costs[i][1])) || (!route.contains(costs[i][0]) && route.contains(
+                    costs[i][1]
+                ))
+            ) {
+                state = 2 // 둘 중 한 노드만 경로에 포함된 상태
+                route.add(costs[i][0])
+                route.add(costs[i][1])
+            }
+        }
+
+        if (state == 0) {
+            routes.add(mutableSetOf(costs[i][0], costs[i][1])) // 두 노드를 방문한 적이 없다면 새 경로 추가
+        } else if (state == 1) { // 두 노드를 모두 방문했고, 두 노드가 이어져 있는 경우 패스~
+            continue
+        } else { // 두 노드 중 한 노드만 기존 경로에 포함되어있는 경우, 위에서 경로를 업데이트 해주었고, 업데이트에 따라 기존 경로들을 합칠 수 있으면 합쳐준다.
+            var j = 0
+            while (j < routes.size - 1) {
+                if (routes[j].intersect(routes[j + 1]).isNotEmpty()) { // 중복된 노드가 있어 경로를 이을 수 있는 경우,
+                    routes[j].union(routes[j + 1])
+                    routes.removeAt(j + 1)
+                }
+                j++
+            }
+        }
+
+        ans += costs[i][2]
+        i++
+    }
+
+    return ans
+}


### PR DESCRIPTION
# [섬 연결하기](https://school.programmers.co.kr/learn/courses/30/lessons/42861?language=kotlin)
- 풀이 방식 : 그리디 알고리즘이기 때문에 가중치 정렬이 필요한 건 알았습니다! 처음에 솔루션2방식으로 풀다가 시간초과가 떠서 결국 구글링을 하게되었고 크루스칼 알고리즘을 사용하면 되는 것을 알았습니다 ^^
   - 솔루션 1 : 크루스칼 알고리즘 적용
   - 솔루션 2 : 이어져있는 경로(set)를 담는 route배열을 이용했고, 정렬된 costs를 돌면서 해당 cost의 양끝 노드들이 route 배열에 포함되어있는지 여부를 검사하는데,
   - 만약 두 노드가 모두 하나의 경로안에 포함이 되어있다면 이미 두 곳다 방문한 것으로 간주하여 반복문을 건너뛰고, 
   - 둘 중 한노드만 포함되어있다면 경로 마다 현재의 부분 경로 (두 노드)를 추가합니다. 
      - 이 경우 모든 경로를 돌며 경로마다 중복된 노드가 존재하면 합집합을 사용하여 경로를 합치는 작업을 진행했습니다!
   - 두 노드 모두 포함되어있지 않은 경우 route 배열에 새 경로 집합을 추가했습니다!
<br>

- 시간 복잡도 : O(nlogn)
<br>

- 솔루션 1
<img width="373" alt="image" src="https://user-images.githubusercontent.com/48701368/207066170-bc707f03-46db-406d-bc4b-a8348e9a27ee.png">

- 솔루션 2
<img width="398" alt="KakaoTalk_Photo_2022-12-12-23-13-20" src="https://user-images.githubusercontent.com/48701368/207067241-7bbfbf9b-6673-4856-b3c7-edc028fbade0.png">

