### PR TITLE
[sol] 드래곤 커브 풀이

### DIFF
--- a/implementation/드래곤 커브.kt
+++ b/implementation/드래곤 커브.kt
@@ -1,0 +1,41 @@
+// https://www.acmicpc.net/problem/15685
+
+// 0, 1, 2, 3 방향
+val dx = intArrayOf(1, 0, -1, 0)
+val dy = intArrayOf(0, -1, 0, 1)
+val visited = Array(101) { IntArray(101) }
+
+fun main() {
+    repeat(readln().toInt()) {
+        var (x, y, d, g) = readln().split(" ").map { it.toInt() }
+        val dList = mutableListOf(d)
+        visited[x][y] = 1
+
+        // 세대만큼 반복
+        repeat(g) {
+            val tmp = mutableListOf<Int>() // 이전 세대 커브의 역방향으로 각 요소 d에 (d + 1) % 4를 적용 (4 : 방향은 0 ~ 3으로 나타냄)
+            for (i in dList.size - 1 downTo 0)
+                tmp.add((dList[i] + 1) % 4)
+
+            // 이전 세대 커브에 tmp를 더함
+            dList.addAll(tmp)
+        }
+
+        // dList의 방향값을 통해 좌표 계산 및 방문 처리
+        for (d in dList) {
+            val nx = x + dx[d]
+            val ny = y + dy[d]
+            visited[nx][ny] = 1
+            x = nx; y = ny // 방향을 고려해서 현재 좌표 갱신 처리
+        }
+    }
+
+    // 사각형 갯수 계산
+    var ans = 0
+    for (i in 0 until 100) {
+        for (j in 0 until 100) {
+            if (visited[i][j] == 1 && visited[i + 1][j] == 1 && visited[i][j + 1] == 1 && visited[i + 1][j + 1] == 1) ans += 1
+        }
+    }
+    print(ans)
+}


### PR DESCRIPTION
# [드래곤 커브](https://www.acmicpc.net/problem/15685)
- 풀이 방식 : 시간 내로 풀지 못해서 구글링 찬스 썼답니다 😉
규칙을 찾는 것이 관건인 문제네용!
위의 예시에서 0~3세대 커브를 방향정보(0: ➡️, 1: ⬆️, 2: ⬅️, 3: ⬇️)로 바꾸어 나타내면 다음과 같습니다!
    * 0세대 : 0 
    * 1세대 : 0 1 (0 , (0+1))
    * 2세대 : 0, 1, 2, 1 (0, 1, (1+1), (0+1))
    * 3세대 : 0, 1, 2, 1, 2, 3, 2, 1 (0, 1, 2, 1, (1+1), (2+1), (1+1), (0+1))

- 규칙 : 현재 세대 커브 = 이전세대 커브 방향정보 + 이전세대 커브의 방향정보를 뒤집어서 + 1을 더하기 (단, 방향 + 1 값이 4이상인 경우는 % 4로 나누어 0~3 방향으로 변환해야함.)

* 세대가 증가할 때마다 규칙을 적용해서 방향값을 계산하고, 방향값 리스트(dList)와 시작좌표 x, y값을 이용해서 좌표로 변환하고
* 100×100인 격자를 좌측상단 부터 검사해서 정사각형 좌표를 이루면(꼭지점 4개가 visited = 1) ans += 1합니다!

- 시간 복잡도 : O(n^3)
<img width="166" alt="image" src="https://github.com/SoptJune/YoungJin/assets/48701368/b4c339ed-2c75-41b5-b946-611fbb366bd0">

