### PR TITLE
[sol] 단어 섞기 풀이

### DIFF
--- a/search/단어 섞기.kt
+++ b/search/단어 섞기.kt
@@ -1,0 +1,36 @@
+// https://www.acmicpc.net/problem/9177
+
+import java.util.*
+
+lateinit var visited: Array<IntArray>
+
+fun main() {
+    repeat(readln().toInt()) { idx ->
+        readln().split(" ").let {
+            val yesOrNo = if (isValidDataset(it[0], it[1], it[2])) "yes" else "no"
+            println("Data set ${idx + 1}: $yesOrNo")
+        }
+    }
+}
+
+fun isValidDataset(w1: String, w2: String, w3: String): Boolean {
+    visited = Array(w1.length + 1) { IntArray(w2.length + 1) }
+    val queue = LinkedList(listOf(Triple(0, 0, 0)))
+
+    while (queue.isNotEmpty()) {
+        val (w1Idx, w2Idx, w3Idx) = queue.pop()
+        if (w3Idx == w3.length) {
+            return true
+        }
+        if (w1Idx < w1.length && visited[w1Idx + 1][w2Idx] == 0 && w1[w1Idx] == w3[w3Idx]) {
+            visited[w1Idx + 1][w2Idx] = 1
+            queue.add(Triple(w1Idx + 1, w2Idx, w3Idx + 1))
+        }
+        if (w2Idx < w2.length && visited[w1Idx][w2Idx + 1] == 0 && w2[w2Idx] == w3[w3Idx]) {
+            visited[w1Idx][w2Idx + 1] = 1
+            queue.add(Triple(w1Idx, w2Idx + 1, w3Idx + 1))
+        }
+    }
+
+    return false
+}


### PR DESCRIPTION
# [단어 섞기](https://www.acmicpc.net/problem/9177)
- 풀이 방식 : 처음에 문제를 잘못 이해해서 단어 1, 2를 문자형태로 각각 큐에 넣고 단어3을 순회하면서 큐에서 각 문자 꺼내면서 검사했었어요!
- 근데 두번째 예시에서 "cat tree catrtee" 의 경우 yes가 나와야하는데 no가 나오더라구요..? 알고보니 위 방식의 경우 모든 경우를 다 탐색하는 게 아니다보니 세번째 단어 catrtee를 만들어가는 중 ca까지 만들고, t를 가져오려고 할 때 cat에서의 t를 사용하면 tree라는 단어가 rtee로 순서가 뒤바뀐 것이 되니 no가 출력된 것이었습니다..!
- 이 문제를 해결하기 위해서는 cat과 tree 둘다 t가 있기 때문에 이 두 케이스를 **모두 검사해서 하나라도 답이 나오는 경우가 있다면 yes로 출력**해야합니다.
- 따라서! 완전탐색 **bfs**로 풀이했어용~!

1. 각 단어셋마다 w1(첫번째 단어), w2(두번째 단어), w3(세번째 단어) 초기 인덱스 (0, 0, 0)를 부여해서
2. 해당 인덱스 정보를 방문하지 않았고, w1의 인덱스가 가리키는 문자와 w2의 인덱스가 가리키는 문자 중에서 w3인덱스가 가리키는 문자와 같다면 해당 인덱스 정보를 큐에 삽입합니다.
3. bfs를 진행해서 w3를 순회여부에 따라 yes 또는 no를 출력합니다.

- 시간 복잡도 : O(n^2)
<img width="160" alt="image" src="https://github.com/SoptJune/YoungJin/assets/48701368/49996425-351d-41f5-ae8e-c64be5e1cf0b">

