### PR TITLE
[sol] 멀티탭 스케줄링 풀이

### DIFF
--- a/greedy/멀티탭 스케줄링.kt
+++ b/greedy/멀티탭 스케줄링.kt
@@ -1,0 +1,60 @@
+// https://www.acmicpc.net/problem/1700
+
+var count = 0
+lateinit var multiTab: Array<String>
+lateinit var schedule: List<String>
+val plugMap: HashMap<String, Int> = hashMapOf()
+const val EMPTY = "empty"
+
+fun main() {
+    val (size, _) = readln().split(" ").map { it.toInt() }
+    multiTab = Array(size) { EMPTY }
+    schedule = readln().split(" ")
+    schedule.forEach { p ->
+        plugMap[p] = plugMap[p]?.plus(1) ?: 1
+    }
+
+    schedule.forEachIndexed { idx, plug ->
+        if (plug !in multiTab) { // 1. 플러그가 꽂혀있지 않은 경우
+            val emptyPos = multiTab.indexOf(EMPTY)
+            if (emptyPos >= 0) { // 1.1. 플러그를 꽂을 빈곳이 있다면 플러그 꽂기
+                plugIn(emptyPos, plug)
+            } else { // 1.2. 빈곳이 없다면 플러그 교체
+                changePlug(idx, plug)
+                count++
+            }
+        } else { // 2. 플러그가 꽂혀있는 경우
+            plugIn(plug = plug)
+        }
+    }
+
+    print(count)
+}
+
+fun changePlug(pos: Int, newPlug: String) {
+    for (i in multiTab.indices) { // 1.2.1. 앞으로 꽂지 않을 플러그라면 멀티탭에서 제거하고 새 플러그를 꽂는다.
+        val originPlug = multiTab[i]
+        if (plugMap[originPlug] == 0) {
+            plugIn(i, newPlug)
+            return
+        }
+    }
+
+    var lastPlug = multiTab[0] // 1.2.2. 꽂혀있는 플러그 중에 첫번째로 가장 늦게 나오는 플러그를 제거하고 새 플러그를 꽂는다.
+    val plugSet = hashSetOf<String>()
+    for (i in pos + 1 until schedule.size) {
+        if (plugSet.size == multiTab.size) break
+        if (schedule[i] in multiTab) {
+            lastPlug = schedule[i]
+            plugSet.add(lastPlug)
+        }
+    }
+
+    plugIn(multiTab.indexOf(lastPlug), newPlug)
+}
+
+/** 해당 플러그를 스케줄링 처리 및 꽂으려고 하는 플러그가 멀티탭에 꽂혀있지 않다면 해당 포지션에 플러그를 꽂음 */
+fun plugIn(pos: Int? = null, plug: String) {
+    plugMap[plug] = plugMap[plug]!!.minus(1)
+    if (pos != null) multiTab[pos] = plug
+}


### PR DESCRIPTION
# [멀티탭 스케줄링](https://www.acmicpc.net/problem/1700)
- 풀이 방식 : **그리디 알고리즘**으로 풀이했습니다! 그리디 선택 조건이 단순한 정렬 적용이 아니라서 옴총 어려웠습니다..
변수 plugMap의 경우 플러그 별로 남은 스케줄 횟수를 map 형태로 저장하고 있습니다.

1. 멀티탭에 플러그가 꽂혀있지 않은 경우
   1.1 멀티탭에 빈곳이 있다면 빈곳에 플러그를 꽂음 => 스케줄 횟수 -1처리, 멀티탭 업데이트
   1.2 멀티탭에 빈곳이 없다면 기존 플러그 중에서 **그리디하게 하나를 제거**, 해당 자리에 현재 스케줄링 대상 플러그를 꽂음 => 스케줄 횟수 -1처리, 멀티탭 업데이트, 플러그 교체 카운트 증가
      1.2.1 멀티탭에 있는 플러그 중에 **이후 스케줄링 대상에 없는 플러그를 제거**
      1.2.2 위 케이스에서 플러그를 제거하지 못했다면 **첫번째 시점에 제일 나중에 스케줄링 되는 플러그를 제거**
2. 멀티탭에 플러그가 꽂혀있는 경우
   2.1 해당 플러그를 스케줄링 처리만 함! => 스케줄링 횟수 -1처리

- 시간 복잡도 : O(n^3)
<img width="260" alt="image" src="https://github.com/SoptJune/YoungJin/assets/48701368/ad283207-46d8-4f38-ab64-2bbaca7a94b6">


