### PR TITLE
[sol] 멀티탭 스케줄링 getOrDefault 적용

### DIFF
--- a/greedy/멀티탭 스케줄링.kt
+++ b/greedy/멀티탭 스케줄링.kt
@@ -11,7 +11,7 @@ fun main() {
     multiTab = Array(size) { EMPTY }
     schedule = readln().split(" ")
     schedule.forEach { p ->
-        plugMap[p] = plugMap[p]?.plus(1) ?: 1
+        plugMap[p] = plugMap.getOrDefault(p, 0).plus(1)
     }
 
     schedule.forEachIndexed { idx, plug ->
@@ -55,6 +55,6 @@ fun changePlug(pos: Int, newPlug: String) {
 
 /** 해당 플러그를 스케줄링 처리 및 꽂으려고 하는 플러그가 멀티탭에 꽂혀있지 않다면 해당 포지션에 플러그를 꽂음 */
 fun plugIn(pos: Int? = null, plug: String) {
-    plugMap[plug] = plugMap[plug]!!.minus(1)
+    plugMap[plug] = plugMap.getOrDefault(plug, 0).minus(1)
     if (pos != null) multiTab[pos] = plug
 }


### PR DESCRIPTION
# [멀티탭 스케줄링](https://www.acmicpc.net/problem/1700)
- 풀이 방식 : [이전 pr](https://github.com/SoptJune/YoungJin/pull/71)을 머지해서 새로 작성했어용! 변경사항은 다음과 같습니다!
```kotlin
// 기존
plugMap[p] = plugMap[p]?.plus(1) ?: 1
// 변경
plugMap[p] = plugMap.getOrDefault(p, 0).plus(1)
```
- 시간 복잡도 : O(n^3)
<img width="278" alt="image" src="https://github.com/SoptJune/YoungJin/assets/48701368/f06a35a4-77c3-4f6f-a070-bd7aa20f91d0">
